### PR TITLE
RemoveSource function corrected.

### DIFF
--- a/ughub.py
+++ b/ughub.py
@@ -624,10 +624,10 @@ def BuildPackageDependencyList(packageName, availablePackages, source=None,
 
 def CheckSourceBeforeRemoval(source, origin = "origin"):
 	"""
-	Check if a source can savely be removed
+	Checks if a source can safely be removed and indicates this by return value
 	:param source: the source
 	:param origin: the remote origin
-	:return: True if source repository can be removed save
+	:return: True if source repository may be removed harmlessly otherwise False
 	"""
 	# repository has upstream origin
 	p = subprocess.Popen("git remote -v".split(), cwd = os.path.join(os.path.join(".ughub", "sources"), source), stdout=subprocess.PIPE)

--- a/ughub.py
+++ b/ughub.py
@@ -174,6 +174,36 @@ def PrintSource(s):
 	print("  {0:8}: '{1}'".format("branch", s["branch"]))
 	print("  {0:8}: '{1}'".format("url", s["url"]))
 
+def PurgeSource(args):
+   """ TODO: Purges the specified source from the filesystem if found """
+   pass
+
+def RemoveSource(args):
+   """ Removes specified source from the sources list if found """
+   if (len(args) < 1 or args[0][0] == "-"):
+      print("ERROR in removesource: Invalid arguments specified. See 'ughub help removesource'.")
+      return
+   
+   sources = LoadSources()
+   if not sources: return
+
+   name = args[0]
+   found = False
+   elem = []
+   for source in sources:
+     if (source['name'] == name):
+         found = True
+         elem = source
+
+   if found:
+      print("The following source was removed: '%s'" % name)
+      PrintSource(source)
+      sources.remove(source)
+      WriteSources(sources)
+      # PurgeSource(name)
+   else:
+      print("The following source '%s' was scheduled to be removed but was not found." % name)
+
 
 def AddSource(args):
 	if len(args) < 2 or args[0][0] == "-" or args[1][0] == "-":
@@ -965,6 +995,12 @@ def RunUGHub(args):
 
 		if cmd == "addsource":
 			AddSource(args[1:])
+   
+		elif cmd == "removesource":
+			RemoveSource(args[1:])
+    
+		elif cmd == "purgesource":
+			PurgeSource(args[1:])
 
 		elif cmd == "help":
 			print("")

--- a/ughub.py
+++ b/ughub.py
@@ -179,8 +179,7 @@ def PurgeSource(*sources):
 	"""
 	Purges the sources from the filesystem.
 	Supply a list and unpack with the splat operator or provide varargs the regular way.
-	:return:
-    :param sources:
+    :param sources: the sources to be purged
     :return:
     """
 	if (len(sources) == 0): return

--- a/ughub.py
+++ b/ughub.py
@@ -222,7 +222,8 @@ def RemoveSource(args):
 		if (CheckSourceBeforeRemoval(name) or force):
 			PurgeSource(name)
 		else:
-			print("The following source '%s' has either no remote origin, uncommited (local) changes or unpushed (local) commits. To force removal specify -f or --force." % name)
+			print("The following source '%s' has either no remote origin, uncommited (local) changes or unpushed "
+				  "(local) commits. To force removal specify -f or --force." % name)
 	else:
 		print("The following source '%s' was scheduled to be removed but was not found." % name)
 
@@ -620,6 +621,7 @@ def BuildPackageDependencyList(packageName, availablePackages, source=None,
 							  .format(packageName))
 	return packagesOut
 
+
 def CheckSourceBeforeRemoval(source, origin = "origin"):
 	"""
 	Check if a source can savely be removed
@@ -634,19 +636,22 @@ def CheckSourceBeforeRemoval(source, origin = "origin"):
 		for line in gitLog.splitlines():
 			m1 = re.match("^origin\s+(.+?)\s+\(fetch\)$", line)
 			m2 = re.match("^origin\s+(.+?)\s+\(push\)$", line)
-			if not (m1 and m2): return False
+			if not (m1 and m2):
+				return False
 
 	# repository has no (local) changes
 	p = subprocess.Popen("git diff-index --quiet HEAD --".split(), cwd = os.path.join(os.path.join(".ughub", "sources"), source), stdout=subprocess.PIPE)
 	gitLog = p.communicate()[0].decode("utf-8")
 	if p.returncode != 0:
-		if not len(gitLog.splitLines()) == 0: return False
+		if not len(gitLog.splitLines()) == 0:
+			return False
 
 	# repository has no unpushed (local) commits
 	p = subprocess.Popen("git diff origin/master..HEAD -- ".split(), cwd = os.path.join(os.path.join(".ughub", "sources"), source), stdout=subprocess.PIPE)
 	gitLog = p.communicate()[0].decode("utf-8")
 	if p.returncode != 0:
-		if not len(gitLog.splitlines()) == 0: return False
+		if not len(gitLog.splitlines()) == 0:
+			return False
 
 	return True
 

--- a/ughub.py
+++ b/ughub.py
@@ -824,6 +824,7 @@ def InstallPackage(args):
 			print("WARNING: problems were detected during dry installation run. See above.")
 		return
 
+
 def UninstallPackage(args):
 	"""
 	Uninstalls a package
@@ -903,6 +904,7 @@ def InstallAllPackages(args):
 
 def PackageIsInstalled(pkg):
 	return os.path.isdir(GetPackageDir(pkg))
+
 
 def CallGitOnPackage(pkg, gitCommand, args):
 #todo:	check for changes first for 'commit' and 'push', using e.g.

--- a/ughub.py
+++ b/ughub.py
@@ -856,7 +856,7 @@ def InstallPackage(args):
 
 def UninstallPackage(args):
 	"""
-	Uninstalls a package / TODO check if package can be safely removed, no local changes, git remote and all commits pushed to remote 
+	Uninstalls a package / TODO check if package can be safely removed, no local changes, git remote and all commits pushed to remote
 	:param args:
 	:return:
 	"""
@@ -876,7 +876,7 @@ def UninstallPackage(args):
 		for p in all_packages:
 			if p["name"] == package:
 				print(p["prefix"])
-				if PackageIsInstalled(p):
+				if PackageIsInstalled(p) and CheckPackageBeforeUninstall(p):
 					 import shutil
 					 shutil.rmtree(os.path.join(GetRootDirectory(), os.path.join(p["prefix"], p["name"]))
 

--- a/ughub.py
+++ b/ughub.py
@@ -174,46 +174,58 @@ def PrintSource(s):
 	print("  {0:8}: '{1}'".format("branch", s["branch"]))
 	print("  {0:8}: '{1}'".format("url", s["url"]))
 
-def PurgeSource(args):
-   """ Purges the source from the filesystem"""
-   if len(args) < 1:
-      print("ERROR in purgesource: Invalid arguments specified. See 'ughub help purgesource'.")
-   
-   source = args[0]
-   import shutil
-   shutil.rmtree('.ughub/sources/' + source)
-   Repair([])
+
+def PurgeSource(*sources):
+	"""
+	Purges the sources from the filesystem.
+	Supply a list and unpack with the splat operator or provide varargs the regular way.
+	:return:
+    :param sources:
+    :return:
+    """
+	if (len(sources) == 0): return
+
+	import shutil
+	for source in sources:
+		shutil.rmtree('.ughub/sources/' + source)
+
+	Repair([])
+
 
 def RemoveSource(args):
-   """ Removes specified source from the sources list if found """
-   if (len(args) < 1 or args[0][0] == "-"):
-      print("ERROR in removesource: Invalid arguments specified. See 'ughub help removesource'.")
-      return
-   
-   force = ughubUtil.HasCommandlineOption(args, ("-f", "--force"))
-   sources = LoadSources()
-   if not sources: return
+	"""
+	Removes the specified sources from the internal sources list
+	:param args: command line arguments - the sources' names
+	:return:
+	"""
+	if (len(args) < 1 or args[0][0] == "-"):
+		print("ERROR in removesource: Invalid arguments specified. See 'ughub help removesource'.")
+		return
 
-   name = args[0]
-   found = False
-   elem = []
-   for source in sources:
-     if (source['name'] == name):
-         found = True
-         elem = source
+	force = ughubUtil.HasCommandlineOption(args, ("-f", "--force"))
+	sources = LoadSources()
+	if not sources: return
 
-   if found:
-      print("The following source was removed: '%s'" % name)
-      PrintSource(source)
-      sources.remove(source)
-      WriteSources(sources)
+	name = args[0]
+	found = False
+	elem = []
+	for source in sources:
+		if (source['name'] == name):
+			found = True
+			elem = source
 
-      if (CheckSourceBeforeRemoval(name) or force):
-         PurgeSource([name])
-      else:
-         print("The following source '%s' has either no remote origin, uncommited (local) changes or unpushed (local) commits. To force remove specify -f or --force." % name)
-   else:
-      print("The following source '%s' was scheduled to be removed but was not found." % name)
+	if found:
+		print("The following source was removed: '%s'" % name)
+		PrintSource(source)
+		sources.remove(source)
+		WriteSources(sources)
+		if (CheckSourceBeforeRemoval(name) or force):
+			PurgeSource(name)
+		else:
+			print("The following source '%s' has either no remote origin, uncommited (local) changes or unpushed (local) commits. To force removal specify -f or --force." % name)
+	else:
+		print("The following source '%s' was scheduled to be removed but was not found." % name)
+
 
 def AddSource(args):
 	if len(args) < 2 or args[0][0] == "-" or args[1][0] == "-":
@@ -437,7 +449,7 @@ def LoadFilteredPackageDescs(args):
 
 		if len(allPackages) == 0:
 			return allPackages
-	
+
 		packages = []
 
 		# select according to installed/notinstalled
@@ -455,7 +467,7 @@ def LoadFilteredPackageDescs(args):
 				if not PackageIsInstalled(pkg):
 					packages.append(pkg)
 
-		if not installed and not notinstalled: 
+		if not installed and not notinstalled:
 			for pkg in allPackages:
 				packages.append(pkg)
 
@@ -469,7 +481,7 @@ def LoadFilteredPackageDescs(args):
 
 	except LookupError as e:
 		raise InvalidPackageError(e)
-	
+
 
 def ListPackages(args):
 
@@ -769,7 +781,7 @@ def InstallPackage(args):
 					elif force:
 						print(textRemoteConflictUF.format("WARNING", pkg["name"], wrongURL, pkg["url"]))
 						print("The warning will be ignored (--force). This may result in an outdated package and build conflicts!")
-					
+
 					else:
 						text = textRemoteConflictUF.format("ERROR", pkg["name"], wrongURL, pkg["url"]) + "\n" + textRemoteConflictOptionsUF.format(pkg["url"], pkgPath)
 						if dryRun:
@@ -993,7 +1005,7 @@ def CallGitOnPackages(args, gitCommand):
 
 
 def GenerateProjectFiles(args):
-	
+
 	options			= []
 
 	for i in range(len(args)):
@@ -1035,12 +1047,9 @@ def RunUGHub(args):
 
 		if cmd == "addsource":
 			AddSource(args[1:])
-   
+
 		elif cmd == "removesource":
 			RemoveSource(args[1:])
-    
-		elif cmd == "purgesource":
-			PurgeSource(args[1:])
 
 		elif cmd == "help":
 			print("")

--- a/ughub.py
+++ b/ughub.py
@@ -181,8 +181,8 @@ def PurgeSource(args):
 def RemoveSource(args):
    """ Removes specified source from the sources list if found """
    if (len(args) < 1 or args[0][0] == "-"):
-      print("ERROR in removesource: Invalid arguments specified. See 'ughub help removesource'.")
-      return
+	  print("ERROR in removesource: Invalid arguments specified. See 'ughub help removesource'.")
+	  return
    
    sources = LoadSources()
    if not sources: return
@@ -191,18 +191,18 @@ def RemoveSource(args):
    found = False
    elem = []
    for source in sources:
-     if (source['name'] == name):
-         found = True
-         elem = source
+	 if (source['name'] == name):
+		 found = True
+		 elem = source
 
    if found:
-      print("The following source was removed: '%s'" % name)
-      PrintSource(source)
-      sources.remove(source)
-      WriteSources(sources)
-      # PurgeSource(name)
+	  print("The following source was removed: '%s'" % name)
+	  PrintSource(source)
+	  sources.remove(source)
+	  WriteSources(sources)
+	  # PurgeSource(name)
    else:
-      print("The following source '%s' was scheduled to be removed but was not found." % name)
+	  print("The following source '%s' was scheduled to be removed but was not found." % name)
 
 
 def AddSource(args):
@@ -756,11 +756,11 @@ def InstallPackage(args):
 						print(textBranchConflictUF.format("NOTE", pkg["name"], curBranch, pkg["__BRANCH"]))
 						print("The required branch will be automatically checked out (--resolve)")
 						if not dryRun:
-					 		proc = subprocess.Popen(["git", "checkout", pkg["__BRANCH"]], cwd = pkgPath)
-					 		if proc.wait() != 0:
-					 			raise TransactionError("Trying to resolve branch conflict but couldn't check "
-					 								   "out branch '{0}' of package '{1}' at '{2}'"
-					 								   .format(pkg["__BRANCH"], pkg["name"], pkgPath))
+							proc = subprocess.Popen(["git", "checkout", pkg["__BRANCH"]], cwd = pkgPath)
+							if proc.wait() != 0:
+								raise TransactionError("Trying to resolve branch conflict but couldn't check "
+													   "out branch '{0}' of package '{1}' at '{2}'"
+													   .format(pkg["__BRANCH"], pkg["name"], pkgPath))
 					elif force:
 						print(textBranchConflictUF.format("WARNING", pkg["name"], curBranch, pkg["__BRANCH"]))
 						print("The warning will be ignored (--force). This may result in build problems!")
@@ -846,13 +846,47 @@ def InstallPackage(args):
 
 		else:
 			raise InvalidPackageError("Unsupported repository type of package '{0}': '{1}'"
-							   		  .format(pkg["name"], pkg["repoType"]))
+									  .format(pkg["name"], pkg["repoType"]))
 
 	if dryRun:
 		print("Dry run. Nothing was installed/updated.")
 		if problemsOccurred:
 			print("WARNING: problems were detected during dry installation run. See above.")
 		return
+
+def UninstallPackage(args):
+	"""
+	Uninstalls a package / TODO check if package can be safely removed, no local changes, git remote and all commits pushed to remote 
+	:param args:
+	:return:
+	"""
+	packageNames = args
+
+	for i in range(len(args)):
+		if args[i][0] == "-":
+			packageNames = args[0:i]
+			break
+
+	if len(packageNames) == 0:
+		print("Please specify a package name. See 'ughub help uninstall'.")
+		return
+
+	all_packages = LoadPackageDescs()
+	for package in packageNames:
+		for p in all_packages:
+			if p["name"] == package:
+				print(p["prefix"])
+				if PackageIsInstalled(p):
+					 import shutil
+					 shutil.rmtree(os.path.join(GetRootDirectory(), os.path.join(p["prefix"], p["name"]))
+
+def CheckPackageBeforeUninstall(package):
+	"""
+	Checks if a package can be removed
+	:param package:
+	:return:
+	"""
+	pass
 
 def InstallAllPackages(args):
 	source		= ughubUtil.GetCommandlineOptionValue(args, ("-s", "--source"))
@@ -996,11 +1030,8 @@ def RunUGHub(args):
 		if cmd == "addsource":
 			AddSource(args[1:])
    
-		elif cmd == "removesource":
-			RemoveSource(args[1:])
-    
-		elif cmd == "purgesource":
-			PurgeSource(args[1:])
+		elif cmd == "uninstall":
+			UninstallPackage(args[1:])
 
 		elif cmd == "help":
 			print("")

--- a/ughub.py
+++ b/ughub.py
@@ -175,15 +175,22 @@ def PrintSource(s):
 	print("  {0:8}: '{1}'".format("url", s["url"]))
 
 def PurgeSource(args):
-   """ TODO: Purges the specified source from the filesystem if found """
-   pass
+   """ Purges the source from the filesystem"""
+   if len(args) < 1:
+      print("ERROR in purgesource: Invalid arguments specified. See 'ughub help purgesource'.")
+   
+   source = args[0]
+   import shutil
+   shutil.rmtree('.ughub/sources/' + source)
+   Repair([])
 
 def RemoveSource(args):
    """ Removes specified source from the sources list if found """
-   if (len(args) < 1 or args[0][0] == "-"):
+   if (len(args) < 2 or args[0][0] == "-"):
       print("ERROR in removesource: Invalid arguments specified. See 'ughub help removesource'.")
       return
    
+   purge = ughubUtil.HasCommandlineOption(args, ("-f", "--force"))
    sources = LoadSources()
    if not sources: return
 
@@ -200,10 +207,10 @@ def RemoveSource(args):
       PrintSource(source)
       sources.remove(source)
       WriteSources(sources)
-      # PurgeSource(name)
+      if purge: 
+         PurgeSource([name])
    else:
       print("The following source '%s' was scheduled to be removed but was not found." % name)
-
 
 def AddSource(args):
 	if len(args) < 2 or args[0][0] == "-" or args[1][0] == "-":

--- a/ughubHelpContents.py
+++ b/ughubHelpContents.py
@@ -56,12 +56,18 @@ content = {
 			"name": "removesource",
 			"usage": "removesource NAME",
 			"description": "Removes a package-source (i.e. a git repository) from the sources list\n",
+			"options": [
+				{
+					"name": "-f [--force]",
+					"description":	"Purges after removing package-source all packages installed on filesystem."
+				}
+      ]
 		},
 
 		{
 			"name": "purgesource",
 			"usage": "purgesource NAME",
-			"description": "Purges a package-source (i.e. a git repository) from the filesystem\n",
+			"description": "Purges all packages from source (i.e. all git repositories) from the filesystem\n",
 		},
 
 		{

--- a/ughubHelpContents.py
+++ b/ughubHelpContents.py
@@ -52,17 +52,11 @@ content = {
 			]
 		},
 
-		{
-			"name": "removesource",
-			"usage": "removesource NAME",
-			"description": "Removes a package-source (i.e. a git repository) from the sources list\n",
-		},
-
-		{
-			"name": "purgesource",
-			"usage": "purgesource NAME",
-			"description": "Purges a package-source (i.e. a git repository) from the filesystem\n",
-		},
+		 {
+            "name": "uninstall",
+            "usage": "uninstall NAME",
+            "description": "Uninstall a given package from the filesystem\n"
+        },
 
 		{
 			"name": "genprojectfiles",

--- a/ughubHelpContents.py
+++ b/ughubHelpContents.py
@@ -54,8 +54,14 @@ content = {
 
 		 {
             "name": "uninstall",
-            "usage": "uninstall NAME",
-            "description": "Uninstall a given package from the filesystem\n"
+			 "usage": "uninstall PACKAGE_1 [PACKAGE_2 [PACKAGE_3 [...]]] [OPTIONS]",
+			 "description":	"Uninstalls the specified packages and removes their contents from the file system\n",
+			 "options": [
+				 {
+					 "name": "-f [--force]",
+					 "description":	"Force uninstall of a given package from filesystem even if local changes exist"
+				 }
+			 ]
         },
 
 		{

--- a/ughubHelpContents.py
+++ b/ughubHelpContents.py
@@ -53,6 +53,18 @@ content = {
 		},
 
 		{
+			"name": "removesource",
+			"usage": "removesource NAME",
+			"description": "Removes a package-source (i.e. a git repository) from the sources list\n",
+		},
+
+		{
+			"name": "purgesource",
+			"usage": "purgesource NAME",
+			"description": "Purges a package-source (i.e. a git repository) from the filesystem\n",
+		},
+
+		{
 			"name": "genprojectfiles",
 			"usage": "genprojectfiles TARGET [OPTIONS]",
 			"description":	"Generates project-files for the given TARGET platform.\n"
@@ -324,12 +336,6 @@ content = {
 		# 	"description":	"Ranks the source with the given NAME at the given RANK. If the same\n"
 		# 					"package is contained in multiple sources, the one with the lower rank\n"
 		# 					"is used by default."
-		# },
-
-		# {
-		# 	"name": "removesource",
-		# 	"usage": "removesource NAME",
-		# 	"description":	"Removes the source with the given NAME."
 		# },
 
 		{

--- a/ughubHelpContents.py
+++ b/ughubHelpContents.py
@@ -59,15 +59,9 @@ content = {
 			"options": [
 				{
 					"name": "-f [--force]",
-					"description":	"Purges after removing package-source all packages installed on filesystem."
+					"description":	"Purge the source from the filesystem even if there are uncommited changes or unpushed changes or no remote origin exists for this repository"
 				}
       ]
-		},
-
-		{
-			"name": "purgesource",
-			"usage": "purgesource NAME",
-			"description": "Purges all packages from source (i.e. all git repositories) from the filesystem\n",
 		},
 
 		{


### PR DESCRIPTION
A source may be removed with ughub removesource SOURCE_NAME.
A check is performed if the corresponding source repository has no uncommited changes, has pushed all commits to remote and in particular if a remote exists.

If one wants to force removal of the source specify -f or --force.

For now the corresponding packages installed with the help of this source are NOT removed.
(Could use a switch --remove or -r for removesource to uninstall all associated packages automatically)
