### PR TITLE
UninstallPackage function corrected.

### DIFF
--- a/ughub.py
+++ b/ughub.py
@@ -174,6 +174,36 @@ def PrintSource(s):
 	print("  {0:8}: '{1}'".format("branch", s["branch"]))
 	print("  {0:8}: '{1}'".format("url", s["url"]))
 
+def PurgeSource(args):
+   """ TODO: Purges the specified source from the filesystem if found """
+   pass
+
+def RemoveSource(args):
+   """ Removes specified source from the sources list if found """
+   if (len(args) < 1 or args[0][0] == "-"):
+      print("ERROR in removesource: Invalid arguments specified. See 'ughub help removesource'.")
+      return
+   
+   sources = LoadSources()
+   if not sources: return
+
+   name = args[0]
+   found = False
+   elem = []
+   for source in sources:
+     if (source['name'] == name):
+         found = True
+         elem = source
+
+   if found:
+      print("The following source was removed: '%s'" % name)
+      PrintSource(source)
+      sources.remove(source)
+      WriteSources(sources)
+      # PurgeSource(name)
+   else:
+      print("The following source '%s' was scheduled to be removed but was not found." % name)
+
 
 def AddSource(args):
 	if len(args) < 2 or args[0][0] == "-" or args[1][0] == "-":
@@ -965,6 +995,12 @@ def RunUGHub(args):
 
 		if cmd == "addsource":
 			AddSource(args[1:])
+   
+		elif cmd == "removesource":
+			RemoveSource(args[1:])
+    
+		elif cmd == "purgesource":
+			PurgeSource(args[1:])
 
 		elif cmd == "help":
 			print("")

--- a/ughub.py
+++ b/ughub.py
@@ -824,6 +824,7 @@ def InstallPackage(args):
 			print("WARNING: problems were detected during dry installation run. See above.")
 		return
 
+
 def UninstallPackage(args):
 	"""
 	Uninstalls a package
@@ -903,6 +904,7 @@ def InstallAllPackages(args):
 
 def PackageIsInstalled(pkg):
 	return os.path.isdir(GetPackageDir(pkg))
+
 
 def CallGitOnPackage(pkg, gitCommand, args):
 #todo:	check for changes first for 'commit' and 'push', using e.g.

--- a/ughub.py
+++ b/ughub.py
@@ -856,7 +856,7 @@ def InstallPackage(args):
 
 def UninstallPackage(args):
 	"""
-	Uninstalls a package / TODO check if package can be safely removed, no local changes, git remote and all commits pushed to remote 
+	Uninstalls a package / TODO check if package can be safely removed, no local changes, git remote and all commits pushed to remote
 	:param args:
 	:return:
 	"""
@@ -876,7 +876,7 @@ def UninstallPackage(args):
 		for p in all_packages:
 			if p["name"] == package:
 				print(p["prefix"])
-				if PackageIsInstalled(p):
+				if PackageIsInstalled(p) and CheckPackageBeforeUninstall(p):
 					 import shutil
 					 shutil.rmtree(os.path.join(GetRootDirectory(), os.path.join(p["prefix"], p["name"]))
 

--- a/ughub.py
+++ b/ughub.py
@@ -181,8 +181,8 @@ def PurgeSource(args):
 def RemoveSource(args):
    """ Removes specified source from the sources list if found """
    if (len(args) < 1 or args[0][0] == "-"):
-      print("ERROR in removesource: Invalid arguments specified. See 'ughub help removesource'.")
-      return
+	  print("ERROR in removesource: Invalid arguments specified. See 'ughub help removesource'.")
+	  return
    
    sources = LoadSources()
    if not sources: return
@@ -191,18 +191,18 @@ def RemoveSource(args):
    found = False
    elem = []
    for source in sources:
-     if (source['name'] == name):
-         found = True
-         elem = source
+	 if (source['name'] == name):
+		 found = True
+		 elem = source
 
    if found:
-      print("The following source was removed: '%s'" % name)
-      PrintSource(source)
-      sources.remove(source)
-      WriteSources(sources)
-      # PurgeSource(name)
+	  print("The following source was removed: '%s'" % name)
+	  PrintSource(source)
+	  sources.remove(source)
+	  WriteSources(sources)
+	  # PurgeSource(name)
    else:
-      print("The following source '%s' was scheduled to be removed but was not found." % name)
+	  print("The following source '%s' was scheduled to be removed but was not found." % name)
 
 
 def AddSource(args):
@@ -756,11 +756,11 @@ def InstallPackage(args):
 						print(textBranchConflictUF.format("NOTE", pkg["name"], curBranch, pkg["__BRANCH"]))
 						print("The required branch will be automatically checked out (--resolve)")
 						if not dryRun:
-					 		proc = subprocess.Popen(["git", "checkout", pkg["__BRANCH"]], cwd = pkgPath)
-					 		if proc.wait() != 0:
-					 			raise TransactionError("Trying to resolve branch conflict but couldn't check "
-					 								   "out branch '{0}' of package '{1}' at '{2}'"
-					 								   .format(pkg["__BRANCH"], pkg["name"], pkgPath))
+							proc = subprocess.Popen(["git", "checkout", pkg["__BRANCH"]], cwd = pkgPath)
+							if proc.wait() != 0:
+								raise TransactionError("Trying to resolve branch conflict but couldn't check "
+													   "out branch '{0}' of package '{1}' at '{2}'"
+													   .format(pkg["__BRANCH"], pkg["name"], pkgPath))
 					elif force:
 						print(textBranchConflictUF.format("WARNING", pkg["name"], curBranch, pkg["__BRANCH"]))
 						print("The warning will be ignored (--force). This may result in build problems!")
@@ -846,13 +846,47 @@ def InstallPackage(args):
 
 		else:
 			raise InvalidPackageError("Unsupported repository type of package '{0}': '{1}'"
-							   		  .format(pkg["name"], pkg["repoType"]))
+									  .format(pkg["name"], pkg["repoType"]))
 
 	if dryRun:
 		print("Dry run. Nothing was installed/updated.")
 		if problemsOccurred:
 			print("WARNING: problems were detected during dry installation run. See above.")
 		return
+
+def UninstallPackage(args):
+	"""
+	Uninstalls a package / TODO check if package can be safely removed, no local changes, git remote and all commits pushed to remote 
+	:param args:
+	:return:
+	"""
+	packageNames = args
+
+	for i in range(len(args)):
+		if args[i][0] == "-":
+			packageNames = args[0:i]
+			break
+
+	if len(packageNames) == 0:
+		print("Please specify a package name. See 'ughub help uninstall'.")
+		return
+
+	all_packages = LoadPackageDescs()
+	for package in packageNames:
+		for p in all_packages:
+			if p["name"] == package:
+				print(p["prefix"])
+				if PackageIsInstalled(p):
+					 import shutil
+					 shutil.rmtree(os.path.join(GetRootDirectory(), os.path.join(p["prefix"], p["name"]))
+
+def CheckPackageBeforeUninstall(package):
+	"""
+	Checks if a package can be removed
+	:param package:
+	:return:
+	"""
+	pass
 
 def InstallAllPackages(args):
 	source		= ughubUtil.GetCommandlineOptionValue(args, ("-s", "--source"))
@@ -996,11 +1030,8 @@ def RunUGHub(args):
 		if cmd == "addsource":
 			AddSource(args[1:])
    
-		elif cmd == "removesource":
-			RemoveSource(args[1:])
-    
-		elif cmd == "purgesource":
-			PurgeSource(args[1:])
+		elif cmd == "uninstall":
+			UninstallPackage(args[1:])
 
 		elif cmd == "help":
 			print("")

--- a/ughubHelpContents.py
+++ b/ughubHelpContents.py
@@ -52,17 +52,11 @@ content = {
 			]
 		},
 
-		{
-			"name": "removesource",
-			"usage": "removesource NAME",
-			"description": "Removes a package-source (i.e. a git repository) from the sources list\n",
-		},
-
-		{
-			"name": "purgesource",
-			"usage": "purgesource NAME",
-			"description": "Purges a package-source (i.e. a git repository) from the filesystem\n",
-		},
+		 {
+            "name": "uninstall",
+            "usage": "uninstall NAME",
+            "description": "Uninstall a given package from the filesystem\n"
+        },
 
 		{
 			"name": "genprojectfiles",

--- a/ughubHelpContents.py
+++ b/ughubHelpContents.py
@@ -54,8 +54,14 @@ content = {
 
 		 {
             "name": "uninstall",
-            "usage": "uninstall NAME",
-            "description": "Uninstall a given package from the filesystem\n"
+			 "usage": "uninstall PACKAGE_1 [PACKAGE_2 [PACKAGE_3 [...]]] [OPTIONS]",
+			 "description":	"Uninstalls the specified packages and removes their contents from the file system\n",
+			 "options": [
+				 {
+					 "name": "-f [--force]",
+					 "description":	"Force uninstall of a given package from filesystem even if local changes exist"
+				 }
+			 ]
         },
 
 		{

--- a/ughubHelpContents.py
+++ b/ughubHelpContents.py
@@ -53,6 +53,18 @@ content = {
 		},
 
 		{
+			"name": "removesource",
+			"usage": "removesource NAME",
+			"description": "Removes a package-source (i.e. a git repository) from the sources list\n",
+		},
+
+		{
+			"name": "purgesource",
+			"usage": "purgesource NAME",
+			"description": "Purges a package-source (i.e. a git repository) from the filesystem\n",
+		},
+
+		{
 			"name": "genprojectfiles",
 			"usage": "genprojectfiles TARGET [OPTIONS]",
 			"description":	"Generates project-files for the given TARGET platform.\n"
@@ -324,12 +336,6 @@ content = {
 		# 	"description":	"Ranks the source with the given NAME at the given RANK. If the same\n"
 		# 					"package is contained in multiple sources, the one with the lower rank\n"
 		# 					"is used by default."
-		# },
-
-		# {
-		# 	"name": "removesource",
-		# 	"usage": "removesource NAME",
-		# 	"description":	"Removes the source with the given NAME."
 		# },
 
 		{


### PR DESCRIPTION
A package may be uninstalled by ughup uninstall PACKAGE_NAME.
A check is performed if the corresponding package repository has no uncommited changes, has pushed all commits to remote and in particular if a remote exists.

One could easily enhance for install this method by a source argument which uninstalls all packages from a source, or all packages, ...
